### PR TITLE
Rename DecodedToken to FirebaseToken and add fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,18 @@ encode = ["dep:chrono"]
 rocket = ["dep:rocket"]
 
 [dependencies]
-jsonwebtoken = { version = "8.3.0", features = ["use_pem"] }
-serde = { version = "1.0.158" }
-reqwest = { version = "0.11.15", features = ["json"] }
+jsonwebtoken = { version = "8.3", features = ["use_pem"] }
+serde = { version = "1.0" }
+reqwest = { version = "0.11", features = ["json"] }
 
 rocket = { version = "0.5.0-rc.3", features = ["json"], optional = true }
-dotenvy = { version = "0.15.6", optional = true }
-serde_json = { version = "1.0.94", optional = true }
+dotenvy = { version = "0.15", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 chrono = { version = "0.4", features = ["serde"], optional = true }
 
 [dev-dependencies]
-wiremock = "0.5.17"
-tokio = { version = "1.26.0", features = ["full"] }
-toml = "0.7.3"
-once_cell = "1.17.1"
+wiremock = "0.5"
+tokio = { version = "1.26", features = ["full"] }
+toml = "0.7"
+once_cell = "1.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket_firebase_auth"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 
 description = "Encode/decode firebase tokens in rocket apps with ease"

--- a/examples/react-rocket-example/server/Cargo.toml
+++ b/examples/react-rocket-example/server/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-# serde ... to add serialization/deserialization of api structs
-serde = "1.0.158"
-# rocket ... 🚀
-rocket = { version = "0.5.0-rc.2", features = ["json"] }
-# rocket_cors ... we can set cors options ourselves, but I found using this crate 
-#   to be a more developer friendly experience.
-rocket_cors = { git = "https://github.com/lawliet89/rocket_cors", rev = "54fae0701dffbe5df686465780218644ee3fae5f" }
-# rocket_firebase_auth ... so we can use firebase tokens hassle-free!
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+rocket = { version = "0.5.0-rc.3", features = ["json"] }
 rocket_firebase_auth = { path = "../../../" }
+rocket_cors = "0.6.0-alpha2"

--- a/examples/react-rocket-example/server/rustfmt.toml
+++ b/examples/react-rocket-example/server/rustfmt.toml
@@ -1,4 +1,0 @@
-imports_layout = "HorizontalVertical"
-imports_granularity = "Crate"
-struct_field_align_threshold = 20
-max_width = 80

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,12 @@
 //! // If the token is invalid, return with a `Forbidden` status code.
 //! #[get("/")]
 //! async fn hello_world(state: &State<ServerState>, token: BearerToken) -> Status {
-//!     let token = state.auth.verify(&token).await; // verify token
+//!     let token = state.auth.verify(token.as_str()).await; // verify token
 //!
 //!     match token // extract uid from decoded token
 //!     {
 //!         Ok(token) => {
-//!             println!("Authentication succeeded with uid={}", token.uid);
+//!             println!("Authentication succeeded with uid={}", token.sub);
 //!             Status::Ok
 //!         }
 //!         Err(_) => {
@@ -284,13 +284,11 @@ impl FirebaseAuthBuilder {
 
     /// Add credentials to the builder
     ///
-    ///
-    ///
     /// # Example
     ///
     /// ```rust
-    /// use rocket_firebase_auth::{FirebaseAdminCredentials, FirebaseAuth};
-    ///
+    /// # use rocket_firebase_auth::{FirebaseAdminCredentials, FirebaseAuth};
+    /// #
     /// let credentials = FirebaseAdminCredentials::new(
     ///     project_id: "my-project".to_string(),
     ///     private_key_id: "my-private-key-id".to_string(),
@@ -321,8 +319,8 @@ impl FirebaseAuthBuilder {
     /// # Example
     ///
     /// ```rust
-    /// use rocket_firebase_auth::FirebaseAuth;
-    ///
+    /// # use rocket_firebase_auth::FirebaseAuth;
+    /// #
     /// let auth = FirebaseAuth::builder()
     ///     .jwks_url("https://my-custom-jwks-url.com")
     ///     .build()
@@ -341,8 +339,8 @@ impl FirebaseAuthBuilder {
     /// # Example
     ///
     /// ```rust, no_run
-    /// use rocket_firebase_auth::FirebaseAuth;
-    ///
+    /// # use rocket_firebase_auth::FirebaseAuth;
+    /// #
     /// let auth = FirebaseAuth::builder()
     ///     .env("FIREBASE_CREDENTIALS")
     ///     .build()
@@ -366,8 +364,8 @@ impl FirebaseAuthBuilder {
     /// # Example
     ///
     /// ```rust, no_run
-    /// use rocket_firebase_auth::FirebaseAuth;
-    ///
+    /// # use rocket_firebase_auth::FirebaseAuth;
+    /// #
     /// let auth = FirebaseAuth::builder()
     ///     .env_file(".env", "FIREBASE_CREDENTIALS")
     ///     .build()
@@ -387,8 +385,8 @@ impl FirebaseAuthBuilder {
     /// # Example
     ///
     /// ```rust, no_run
-    /// use rocket_firebase_auth::FirebaseAuth;
-    ///
+    /// # use rocket_firebase_auth::FirebaseAuth;
+    /// #
     /// let auth = FirebaseAuth::builder()
     ///     .json_file("credentials.json")
     ///     .build()
@@ -412,8 +410,8 @@ impl FirebaseAuthBuilder {
     /// # Example
     ///
     /// ```rust, no_run
-    /// use rocket_firebase_auth::FirebaseAuth;
-    ///
+    /// # use rocket_firebase_auth::FirebaseAuth;
+    /// #
     /// let auth = FirebaseAuth::builder()
     ///     .build()
     ///     .unwrap();
@@ -481,11 +479,11 @@ impl FirebaseAuth {
     /// # Examples
     ///
     /// ```rust
-    /// use rocket_firebase_auth::{
-    ///     auth::FirebaseAuth,
-    ///     errors::AuthError
-    /// };
-    ///
+    /// # use rocket_firebase_auth::{
+    /// #    auth::FirebaseAuth,
+    /// #    errors::AuthError
+    /// # };
+    /// #
     /// async fn something(auth: &FirebaseAuth) {
     ///     let uid = "...";
     ///     let project_id = "...";
@@ -523,12 +521,12 @@ impl FirebaseAuth {
     /// # Examples
     ///
     /// ```rust, no_run
-    /// use rocket::{get, State, response::status, http::Status};
-    /// use rocket_firebase_auth::{
-    ///     BearerToken,
-    ///     FirebaseAuth
-    /// };
-    ///
+    /// # use rocket::{get, State, response::status, http::Status};
+    /// # use rocket_firebase_auth::{
+    /// #     BearerToken,
+    /// #     FirebaseAuth
+    /// # };
+    /// #
     /// struct ServerState {
     ///     auth: FirebaseAuth
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,20 +93,69 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "env")]
 use std::{env, fs::read_to_string};
 
-/// Endpoint to fetch JWKs when verifying firebase tokens
-pub static JWKS_URL: &str =
-    "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com";
-
 /// The claims of a decoded JWT token used in firebase
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Jwt {
+///
+/// Google's ID tokens conforms to [OIDC's specifications](https://openid.net/specs/openid-connect-core-1_0.html)
+/// (as per [docs](https://cloud.google.com/docs/authentication/token-types#id)).
+/// Some optional fields like `at_hash` are Google specific, so for more detail
+/// on those, see Google's [discovery page](https://developers.google.com/identity/openid-connect/openid-connect#discovery)
+/// for it's OpenID Connect support.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirebaseToken {
+    /// The audience of the token. The value of this claim must match the
+    /// application or service that uses the token to authenticate the request
     pub aud: String,
+    /// The issuer, or signer, of the token. For Google-signed ID tokens, this
+    /// value is https://accounts.google.com
+    pub iss: String,
+    /// Time the token was issued at in UNIX epoch. Must be in the past
     pub iat: u64,
+    /// Time the token is set to expire in UNIX epoch. Must be in the future.
     pub exp: u64,
+    /// User ID issued by Firebase
     pub sub: String,
+    /// Who the token was issued to
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub azp: Option<String>,
+    /// The user's email address. Provided only if your scope included the email
+    /// scope value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// True if the user's e-mail address has been verified; otherwise false
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email_verified: Option<bool>,
+    /// The user's surname(s) or last name(s)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub family_name: Option<String>,
+    /// The user's given name(s) or first name(s)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub given_name: Option<String>,
+    /// Access token hash. See Google's discovery page for details
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub at_hash: Option<String>,
+    /// The domain associated with Google Cloud organization of the user
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hd: Option<String>,
+    /// The user's locale, represented by a BCP47 language tag
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    /// The user's full name in a displayable form
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The value of the nonce supplied by the app in the authentication request
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+    /// The URL of the user's profile picture
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub picture: Option<String>,
+    /// The URL of the user's profile page
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
 }
 
-impl Jwt {
+impl FirebaseToken {
+    pub const ISSUER_IDENTIFIER: &str = "https://accounts.google.com";
+
     /// Creates a new Jwt token
     ///
     /// The new token is created with a given Firebase `uid` and `project_id`.
@@ -117,7 +166,20 @@ impl Jwt {
             aud: project_id.to_string(),
             iat,
             exp: iat + (60 * 60),
+            iss: Self::ISSUER_IDENTIFIER.to_string(),
             sub: uid.to_string(),
+            azp: None,
+            email: None,
+            email_verified: None,
+            family_name: None,
+            given_name: None,
+            at_hash: None,
+            hd: None,
+            locale: None,
+            name: None,
+            nonce: None,
+            picture: None,
+            profile: None,
         }
     }
 }
@@ -127,36 +189,38 @@ impl Jwt {
 #[derive(Debug)]
 pub struct EncodedToken(pub String);
 
-/// The decoded Firebase JWT token with fields renamed to match Firebase's
-/// mapped values.
-///
-/// jwt.claims.iat => decoded_token.issued_at
-/// jwt.claims.exp => decoded_token.expires_at
-/// jwt.claims.sub => decoded_token.uid
-#[derive(Debug)]
-pub struct DecodedToken {
-    /// Time the token was issued at in UNIX epoch. Must be in the past
-    pub issued_at: u64,
-    /// Time the token is set to expire in UNIX epoch. Must be in the future.
-    pub expires_at: u64,
-    /// User ID issued by Firebase
-    pub uid: String,
-}
-
 /// A partial representation of firebase admin object provided by firebase.
 ///
 /// The fields in the firebase admin object is necessary when encoding and
 /// decoding tokens. All fields should be kept secret.
 #[derive(Debug, Clone, Deserialize, Default)]
-pub struct Credentials {
+pub struct FirebaseAdminCredentials {
     /// The project_id will be used as the `aud` in JWT tokens
-    pub project_id: String,
+    project_id: String,
     /// The private_key_id will be used as the `kid` in JWT tokens
-    pub private_key_id: String,
+    private_key_id: String,
     /// The private_key is the private RSA key used to sign the token
-    pub private_key: String,
-    pub client_email: String,
-    pub client_id: String,
+    private_key: String,
+    client_email: String,
+    client_id: String,
+}
+
+impl FirebaseAdminCredentials {
+    pub fn new(
+        project_id: String,
+        private_key_id: String,
+        private_key: String,
+        client_email: String,
+        client_id: String,
+    ) -> Self {
+        Self {
+            project_id,
+            private_key_id,
+            private_key,
+            client_email,
+            client_id,
+        }
+    }
 }
 
 /// Firebase Auth instance
@@ -167,7 +231,7 @@ pub struct Credentials {
 /// over the values used, specify as, for example, localhost to mock the response.
 #[derive(Debug, Clone)]
 pub struct FirebaseAuth {
-    pub(crate) credentials: Credentials,
+    pub(crate) admin_credentials: FirebaseAdminCredentials,
     pub jwks_url: String,
     pub(crate) client: reqwest::Client,
 }
@@ -176,8 +240,8 @@ impl Default for FirebaseAuth {
     fn default() -> Self {
         let client = reqwest::Client::new();
         Self {
-            credentials: Credentials::default(),
-            jwks_url: JWKS_URL.to_string(),
+            admin_credentials: FirebaseAdminCredentials::default(),
+            jwks_url: Self::JWKS_URL.to_string(),
             client,
         }
     }
@@ -197,7 +261,7 @@ pub enum EnvSource {
 
 #[derive(Debug, Clone)]
 pub struct FirebaseAuthBuilder {
-    credentials: Credentials,
+    admin_credentials: FirebaseAdminCredentials,
     jwks_url: String,
     env_source: EnvSource,
 }
@@ -205,8 +269,8 @@ pub struct FirebaseAuthBuilder {
 impl Default for FirebaseAuthBuilder {
     fn default() -> Self {
         Self {
-            credentials: Credentials::default(),
-            jwks_url: JWKS_URL.to_string(),
+            admin_credentials: FirebaseAdminCredentials::default(),
+            jwks_url: FirebaseAuth::JWKS_URL.to_string(),
             #[cfg(feature = "env")]
             env_source: EnvSource::Var,
         }
@@ -225,23 +289,26 @@ impl FirebaseAuthBuilder {
     /// # Example
     ///
     /// ```rust
-    /// use rocket_firebase_auth::{Credentials, FirebaseAuth};
+    /// use rocket_firebase_auth::{FirebaseAdminCredentials, FirebaseAuth};
     ///
-    /// let credentials = Credentials {
+    /// let credentials = FirebaseAdminCredentials::new(
     ///     project_id: "my-project".to_string(),
     ///     private_key_id: "my-private-key-id".to_string(),
     ///     private_key: "my-private-key".to_string(),
     ///     client_email: "my-client-email".to_string(),
     ///     client_id: "my-client-id".to_string(),
-    /// };
+    /// );
     ///
     /// let auth = FirebaseAuth::builder()
-    ///     .credentials(credentials)
+    ///     .admin_credentials(credentials)
     ///     .build()
     ///     .unwrap();
     /// ```
-    pub fn credentials(mut self, credentials: Credentials) -> Self {
-        self.credentials = credentials;
+    pub fn admin_credentials(
+        mut self,
+        admin_credentials: FirebaseAdminCredentials,
+    ) -> Self {
+        self.admin_credentials = admin_credentials;
         self
     }
 
@@ -361,8 +428,10 @@ impl FirebaseAuthBuilder {
                 dotenvy::from_filename(file_path)?;
                 env::var(variable).map_err(Error::from).and_then(
                     |credentials| {
-                        serde_json::from_str::<Credentials>(&credentials)
-                            .map_err(Error::from)
+                        serde_json::from_str::<FirebaseAdminCredentials>(
+                            &credentials,
+                        )
+                        .map_err(Error::from)
                     },
                 )
             }
@@ -370,14 +439,16 @@ impl FirebaseAuthBuilder {
             EnvSource::Json(filepath) => read_to_string(filepath)
                 .map_err(Error::from)
                 .and_then(|credentials| {
-                    serde_json::from_str::<Credentials>(&credentials)
-                        .map_err(Error::from)
+                    serde_json::from_str::<FirebaseAdminCredentials>(
+                        &credentials,
+                    )
+                    .map_err(Error::from)
                 }),
-            _ => Ok(self.credentials),
+            _ => Ok(self.admin_credentials),
         }?;
 
         Ok(FirebaseAuth {
-            credentials,
+            admin_credentials: credentials,
             jwks_url: self.jwks_url,
             client: reqwest::Client::new(),
         })
@@ -385,11 +456,14 @@ impl FirebaseAuthBuilder {
 }
 
 impl FirebaseAuth {
+    /// Endpoint to fetch JWKs when verifying firebase tokens
+    pub const JWKS_URL: &str = "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com";
+
     /// Create a new FirebaseAuth struct by providing Credentials
-    pub fn new(credentials: Credentials) -> Self {
+    pub fn new(credentials: FirebaseAdminCredentials) -> Self {
         Self {
-            credentials,
-            jwks_url: JWKS_URL.to_string(),
+            admin_credentials: credentials,
+            jwks_url: Self::JWKS_URL.to_string(),
             client: reqwest::Client::new(),
         }
     }
@@ -421,15 +495,18 @@ impl FirebaseAuth {
     #[cfg(feature = "encode")]
     pub fn encode(&self, uid: &str) -> Result<EncodedToken, Error> {
         let header = Header {
-            kid: Some(self.credentials.private_key_id.clone()),
+            kid: Some(self.admin_credentials.private_key_id.clone()),
             ..Header::new(Algorithm::RS256)
         };
 
-        EncodingKey::from_rsa_pem(self.credentials.private_key.as_bytes())
+        EncodingKey::from_rsa_pem(self.admin_credentials.private_key.as_bytes())
             .and_then(|key| {
                 jsonwebtoken::encode(
                     &header,
-                    &Jwt::new(uid, &self.credentials.project_id),
+                    &FirebaseToken::new(
+                        uid,
+                        &self.admin_credentials.project_id,
+                    ),
                     &key,
                 )
             })
@@ -474,24 +551,13 @@ impl FirebaseAuth {
     ///     }
     /// }
     /// ```
-    pub async fn verify(
-        &self,
-        token: &BearerToken,
-    ) -> Result<DecodedToken, Error> {
-        self.verify_token(token.as_str()).await
-    }
-
-    /// Verify Firebase Jwt token in string representation
-    pub async fn verify_token(
-        &self,
-        token: &str,
-    ) -> Result<DecodedToken, Error> {
+    pub async fn verify(&self, token: &str) -> Result<FirebaseToken, Error> {
         let mut validation = Validation::new(Algorithm::RS256);
         validation.set_issuer(&[format!(
             "https://securetoken.google.com/{}",
-            &self.credentials.project_id
+            &self.admin_credentials.project_id
         )]);
-        validation.set_audience(&[&self.credentials.project_id]);
+        validation.set_audience(&[&self.admin_credentials.project_id]);
 
         let kid =
             decode_header(token)
@@ -508,13 +574,9 @@ impl FirebaseAuth {
 
         DecodingKey::from_rsa_components(&jwk.n, &jwk.e)
             .and_then(|key| {
-                jsonwebtoken::decode::<Jwt>(token, &key, &validation)
+                jsonwebtoken::decode::<FirebaseToken>(token, &key, &validation)
             })
-            .map(|token_data| DecodedToken {
-                issued_at: token_data.claims.iat,
-                expires_at: token_data.claims.exp,
-                uid: token_data.claims.sub,
-            })
+            .map(|data| data.claims)
             .map_err(Error::from)
     }
 }
@@ -546,9 +608,9 @@ mod tests {
         let firebase_auth = FirebaseAuth::builder()
             .json_file("tests/env_files/firebase-creds.json")
             .jwks_url("some_dummy_value")
-            .build();
+            .build()
+            .unwrap();
 
-        assert!(firebase_auth.is_ok());
-        assert_eq!(firebase_auth.unwrap().jwks_url, "some_dummy_value");
+        assert_eq!(firebase_auth.jwks_url, "some_dummy_value");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,11 +290,11 @@ impl FirebaseAuthBuilder {
     /// # use rocket_firebase_auth::{FirebaseAdminCredentials, FirebaseAuth};
     /// #
     /// let credentials = FirebaseAdminCredentials::new(
-    ///     project_id: "my-project".to_string(),
-    ///     private_key_id: "my-private-key-id".to_string(),
-    ///     private_key: "my-private-key".to_string(),
-    ///     client_email: "my-client-email".to_string(),
-    ///     client_id: "my-client-id".to_string(),
+    ///     "my-project".to_string(),
+    ///     "my-private-key-id".to_string(),
+    ///     "my-private-key".to_string(),
+    ///     "my-client-email".to_string(),
+    ///     "my-client-id".to_string(),
     /// );
     ///
     /// let auth = FirebaseAuth::builder()
@@ -537,9 +537,9 @@ impl FirebaseAuth {
     ///     token: BearerToken
     /// ) -> Status
     /// {
-    ///     match state.auth.verify(&token).await {
+    ///     match state.auth.verify(token.as_str()).await {
     ///         Ok(decoded_token) => {
-    ///             println!("Valid token. uid: {}", decoded_token.uid);
+    ///             println!("Valid token. uid: {}", decoded_token.sub);
     ///             Status::Ok
     ///         }
     ///         Err(_) => {

--- a/tests/test_firebase_auth.rs
+++ b/tests/test_firebase_auth.rs
@@ -24,15 +24,14 @@ async fn should_succeed_with_env() {
         .jwks_url(TEST_JWKS_URL)
         .build()
         .unwrap();
-    let decoded_token =
-        firebase_auth.verify_token(scenario.token.as_str()).await;
+    let decoded_token = firebase_auth.verify(scenario.token.as_str()).await;
 
     assert!(decoded_token.is_ok());
 
     let decoded_token = decoded_token.unwrap();
 
-    assert_eq!(decoded_token.uid, "some-uid");
-    assert!(decoded_token.expires_at > decoded_token.issued_at);
+    assert_eq!(decoded_token.sub, "some-uid");
+    assert!(decoded_token.exp > decoded_token.iat);
 }
 
 #[tokio::test]
@@ -51,15 +50,14 @@ async fn should_succeed_with_env_with_filename() {
         .jwks_url(TEST_JWKS_URL)
         .build()
         .unwrap();
-    let decoded_token =
-        firebase_auth.verify_token(scenario.token.as_str()).await;
+    let decoded_token = firebase_auth.verify(scenario.token.as_str()).await;
 
     assert!(decoded_token.is_ok());
 
     let decoded_token = decoded_token.unwrap();
 
-    assert_eq!(decoded_token.uid, "some-uid");
-    assert!(decoded_token.expires_at > decoded_token.issued_at);
+    assert_eq!(decoded_token.sub, "some-uid");
+    assert!(decoded_token.exp > decoded_token.iat);
 }
 
 #[tokio::test]
@@ -78,13 +76,12 @@ async fn should_succeed_with_json_file() {
         .jwks_url(TEST_JWKS_URL)
         .build()
         .unwrap();
-    let decoded_token =
-        firebase_auth.verify_token(scenario.token.as_str()).await;
+    let decoded_token = firebase_auth.verify(scenario.token.as_str()).await;
 
     assert!(decoded_token.is_ok());
 
     let decoded_token = decoded_token.unwrap();
 
-    assert_eq!(decoded_token.uid, "some-uid");
-    assert!(decoded_token.expires_at > decoded_token.issued_at);
+    assert_eq!(decoded_token.sub, "some-uid");
+    assert!(decoded_token.exp > decoded_token.iat);
 }

--- a/tests/test_jwt.rs
+++ b/tests/test_jwt.rs
@@ -15,7 +15,7 @@ use rocket_firebase_auth::{
 async fn missing_kid() {
     let token_without_kid = load_scenario("missing_kid").token;
     let decoded_token = FirebaseAuth::default()
-        .verify_token(token_without_kid.as_str())
+        .verify(token_without_kid.as_str())
         .await;
 
     assert!(decoded_token.is_err());
@@ -41,7 +41,7 @@ async fn missing_jwk() {
         .jwks_url(TEST_JWKS_URL)
         .build()
         .unwrap()
-        .verify_token(scenario.token.as_str())
+        .verify(scenario.token.as_str())
         .await;
 
     assert!(decoded_token.is_err());

--- a/tests/test_readme.rs
+++ b/tests/test_readme.rs
@@ -1,16 +1,12 @@
-#[cfg(feature = "rocket")]
 use rocket::{get, http::Status, routes, Build, Rocket, State};
-#[cfg(feature = "rocket")]
 use rocket_firebase_auth::{BearerToken, FirebaseAuth};
 
-#[cfg(feature = "rocket")]
 struct ServerState {
     auth: FirebaseAuth,
 }
 
 // Example function that returns an `Ok` and prints the verified user's uid.
 // If the token is invalid, return with a `Forbidden` status code.
-#[cfg(feature = "rocket")]
 #[get("/")]
 async fn hello_world(state: &State<ServerState>, token: BearerToken) -> Status {
     let token = state.auth.verify(token.as_str()).await; // verify token
@@ -28,7 +24,6 @@ async fn hello_world(state: &State<ServerState>, token: BearerToken) -> Status {
     }
 }
 
-#[cfg(feature = "rocket")]
 #[rocket::launch]
 async fn rocket() -> Rocket<Build> {
     let firebase_auth = FirebaseAuth::builder()

--- a/tests/test_readme.rs
+++ b/tests/test_readme.rs
@@ -13,12 +13,12 @@ struct ServerState {
 #[cfg(feature = "rocket")]
 #[get("/")]
 async fn hello_world(state: &State<ServerState>, token: BearerToken) -> Status {
-    let token = state.auth.verify(&token).await; // verify token
+    let token = state.auth.verify(token.as_str()).await; // verify token
 
     match token // extract uid from decoded token
     {
         Ok(token) => {
-            println!("Authentication succeeded with uid={}", token.uid);
+            println!("Authentication succeeded with uid={}", token.sub);
             Status::Ok
         }
         Err(_) => {


### PR DESCRIPTION
As pointed out in https://github.com/DrPoppyseed/rocket-firebase-auth/pull/5#discussion_r1147971068, `DecodedToken` is a bad variable name. In this PR, I've renamed it to `FirebaseToken`, and added the missing fields (such as `email`). 